### PR TITLE
bootstrap.in: auto-initialize gnulib git submodules

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2911,6 +2911,23 @@ func_update_translations ()
 }
 
 
+# func_gnulib_git_submodules
+# --------------------------
+# Initialize all git modules from $gnulib_git_submodules before we
+# run 'gnulib-tool'.
+func_gnulib_git_submodules ()
+{
+    test -z "$gnulib_git_submodules" && return
+
+    for _G_submodule in $gnulib_git_submodules
+    do
+      func_show_eval "git submodule init -- $_G_submodule" \
+          && func_show_eval "git submodule update -- $_G_submodule" \
+          || func_fatal_error "Unable to init git module '$_G_submodule'."
+    done
+}
+
+
 # func_reconfigure
 # ----------------
 # Reconfigure the current package by running the appropriate autotools in a
@@ -2952,6 +2969,9 @@ func_reconfigure ()
     # warnings if the initial 'aclocal' is confused by the libtoolized
     # (or worse: out-of-date) macro directory.
     func_libtoolize
+
+    # Before we run 'gnulib-tool', we need to have the --local-dir's prepared.
+    func_gnulib_git_submodules
 
     # If you need to do anything after 'gnulib-tool' is done, but before
     # 'autoreconf' runs, you don't need to override this whole function,

--- a/build-aux/bootstrap.in
+++ b/build-aux/bootstrap.in
@@ -341,6 +341,23 @@ func_update_translations ()
 }
 
 
+# func_gnulib_git_submodules
+# --------------------------
+# Initialize all git modules from $gnulib_git_submodules before we
+# run 'gnulib-tool'.
+func_gnulib_git_submodules ()
+{
+    test -z "$gnulib_git_submodules" && return
+
+    for _G_submodule in $gnulib_git_submodules
+    do
+      func_show_eval "git submodule init -- $_G_submodule" \
+          && func_show_eval "git submodule update -- $_G_submodule" \
+          || func_fatal_error "Unable to init git module '$_G_submodule'."
+    done
+}
+
+
 # func_reconfigure
 # ----------------
 # Reconfigure the current package by running the appropriate autotools in a
@@ -382,6 +399,9 @@ func_reconfigure ()
     # warnings if the initial 'aclocal' is confused by the libtoolized
     # (or worse: out-of-date) macro directory.
     func_libtoolize
+
+    # Before we run 'gnulib-tool', we need to have the --local-dir's prepared.
+    func_gnulib_git_submodules
 
     # If you need to do anything after 'gnulib-tool' is done, but before
     # 'autoreconf' runs, you don't need to override this whole function,


### PR DESCRIPTION
The preferred work-flow after this commit would be:

``` bash
$ git submodule add https://github.com/gnulib-modules/bootstrap.git gl-mod/bootstrap
$ vi bootstrap.conf  # add 'gl-mod/bootstrap' into $gnulib_git_modules
$ # git commit and push the changes
```

Users should be able to './bootstrap' the project successfully without manual
`git submodule init && git submodule update`.

Any issues with this new `bootstrap.conf` "API"?
