### PR TITLE
funclib.sh: unset GREP_OPTIONS variable

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -309,6 +309,8 @@ if test "${PATH_SEPARATOR+set}" != set; then
   }
 fi
 
+# Make sure ${,E,F}GREP behave sanely.
+GREP_OPTIONS=; unset GREP_OPTIONS
 
 
 ## ------------------------- ##

--- a/build-aux/funclib.sh
+++ b/build-aux/funclib.sh
@@ -84,6 +84,8 @@ if test "${PATH_SEPARATOR+set}" != set; then
   }
 fi
 
+# Make sure ${,E,F}GREP behave sanely.
+GREP_OPTIONS=; unset GREP_OPTIONS
 
 
 ## ------------------------- ##


### PR DESCRIPTION
Similarly done in not yet released Autoconf.

Libtool reports:
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=16259
http://lists.gnu.org/archive/html/libtool/2016-02/msg00069.html
- build-aux/funclib.sh: Make sure $GREP_OPTIONS does not affect
  calling of $GREP, $FGREP and $EGREP calls.
- bootstrap: Regenerate.
