### PR TITLE
options-parser: fix --version parsing with AIX sed

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2302,20 +2302,20 @@ func_version ()
         /^# Written by /!b
         s|^# ||; p; n
 
-        :fwd2blank
+        :fwd2blnk
         /./ {
           n
-          b fwd2blank
+          b fwd2blnk
         }
         p; n
 
-        :holdwarranty
+        :holdwrnt
         s|^# ||
         s|^# *$||
-        /^Copyright /! {
+        /^Copyright /!{
           /./H
           n
-          b holdwarranty
+          b holdwrnt
         }
 
         s|\((C)\)[ 0-9,-]*[ ,-]\([1-9][0-9]* \)|\1 \2|

--- a/build-aux/options-parser
+++ b/build-aux/options-parser
@@ -651,20 +651,20 @@ func_version ()
         /^# Written by /!b
         s|^# ||; p; n
 
-        :fwd2blank
+        :fwd2blnk
         /./ {
           n
-          b fwd2blank
+          b fwd2blnk
         }
         p; n
 
-        :holdwarranty
+        :holdwrnt
         s|^# ||
         s|^# *$||
-        /^Copyright /! {
+        /^Copyright /!{
           /./H
           n
-          b holdwarranty
+          b holdwrnt
         }
 
         s|\((C)\)[ 0-9,-]*[ ,-]\([1-9][0-9]* \)|\1 \2|


### PR DESCRIPTION
- build-aux/options-parser (func_version): Shorten sed-labels to 8
  characters.
  The sed-command has to immediately follow the selection-command.
- bootstrap: Regenerate.
