### PR TITLE
Fixes to correct missing pathname quoting in various tools.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,6 @@
 #! /bin/sh
 ## DO NOT EDIT - This file generated from build-aux/bootstrap.in
-##               by inline-source v2016-02-21.11
+##               by inline-source v2016-08-16.15
 
 # Bootstrap an Autotooled package from checked-out sources.
 # Written by Gary V. Vaughan, 2010
@@ -224,7 +224,7 @@ vc_ignore=
 
 # Source required external libraries:
 # Set a version string for this script.
-scriptversion=2016-02-28.16; # UTC
+scriptversion=2016-08-15.14; # UTC
 
 # General shell script boiler plate, and helper functions.
 # Written by Gary V. Vaughan, 2004
@@ -370,7 +370,7 @@ func_path_progs ()
           func_executable_p "$_G_path_prog" || continue
           case `"$_G_path_prog" --version 2>&1` in
             *GNU*) func_path_progs_result=$_G_path_prog _G_path_prog_found=: ;;
-            *)     $_G_check_func $_G_path_prog
+            *)     $_G_check_func "$_G_path_prog"
 		   func_path_progs_result=$func_check_prog_result
 		   ;;
           esac
@@ -2355,11 +2355,11 @@ func_version ()
 # <https://github.com/gnulib-modules/bootstrap/issues>
 
 # Make sure we've evaluated scripts we depend on.
-test -z "$progpath" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/funclib.sh
-test extract-trace = "$progname" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/options-parser
+test -z "$progpath" && . "`echo "$0" |${SED-sed} 's|[^/]*$||'`funclib.sh"
+test extract-trace = "$progname" && . "`echo "$0" |${SED-sed} 's|[^/]*$||'`options-parser"
 
 # Set a version string.
-scriptversion=2016-02-22.14; # UTC
+scriptversion=2016-08-15.19; # UTC
 
 
 ## ------ ##
@@ -2503,7 +2503,7 @@ func_find_tool ()
 	  IFS=$_G_find_tool_save_IFS
 	  _G_progpath=$_G_dir/$_G_prog
           test -r "$_G_progpath" && {
-            _G_curver=`func_tool_version_number $_G_progpath`
+            _G_curver=`func_tool_version_number "$_G_progpath"`
 	    case $_G_bestver,$_G_curver in
 	    ,)
 	      # first non--version responsive prog sticks!
@@ -2817,12 +2817,12 @@ test extract-trace = "$progname" && func_main "$@"
 # mode: shell-script
 # sh-indentation: 2
 # eval: (add-hook 'before-save-hook 'time-stamp)
-# time-stamp-pattern: "20/scriptversion=%:y-%02m-%02d.%02H; # UTC"
+# time-stamp-pattern: "30/scriptversion=%:y-%02m-%02d.%02H; # UTC"
 # time-stamp-time-zone: "UTC"
 # End:
 
 # Set a version string for *this* script.
-scriptversion=2016-02-28.16; # UTC
+scriptversion=2016-08-15.19; # UTC
 
 
 ## ------------------- ##

--- a/build-aux/bootstrap.in
+++ b/build-aux/bootstrap.in
@@ -221,12 +221,12 @@ vc_ignore=
 ## ------------------- ##
 
 # Source required external libraries:
-. `echo "$0" |${SED-sed} 's|[^/]*$||'`"funclib.sh"
-. `echo "$0" |${SED-sed} 's|[^/]*$||'`"options-parser"
-. `echo "$0" |${SED-sed} 's|[^/]*$||'`"extract-trace"
+. "`echo "$0" |${SED-sed} 's|[^/]*$||'`funclib.sh"
+. "`echo "$0" |${SED-sed} 's|[^/]*$||'`options-parser"
+. "`echo "$0" |${SED-sed} 's|[^/]*$||'`extract-trace"
 
 # Set a version string for *this* script.
-scriptversion=2016-02-28.16; # UTC
+scriptversion=2016-08-15.19; # UTC
 
 
 ## ------------------- ##

--- a/build-aux/extract-trace
+++ b/build-aux/extract-trace
@@ -19,11 +19,11 @@
 # <https://github.com/gnulib-modules/bootstrap/issues>
 
 # Make sure we've evaluated scripts we depend on.
-test -z "$progpath" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/funclib.sh
-test extract-trace = "$progname" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/options-parser
+test -z "$progpath" && . "`echo "$0" |${SED-sed} 's|[^/]*$||'`funclib.sh"
+test extract-trace = "$progname" && . "`echo "$0" |${SED-sed} 's|[^/]*$||'`options-parser"
 
 # Set a version string.
-scriptversion=2016-02-22.14; # UTC
+scriptversion=2016-08-15.19; # UTC
 
 
 ## ------ ##
@@ -167,7 +167,7 @@ func_find_tool ()
 	  IFS=$_G_find_tool_save_IFS
 	  _G_progpath=$_G_dir/$_G_prog
           test -r "$_G_progpath" && {
-            _G_curver=`func_tool_version_number $_G_progpath`
+            _G_curver=`func_tool_version_number "$_G_progpath"`
 	    case $_G_bestver,$_G_curver in
 	    ,)
 	      # first non--version responsive prog sticks!
@@ -481,6 +481,6 @@ test extract-trace = "$progname" && func_main "$@"
 # mode: shell-script
 # sh-indentation: 2
 # eval: (add-hook 'before-save-hook 'time-stamp)
-# time-stamp-pattern: "20/scriptversion=%:y-%02m-%02d.%02H; # UTC"
+# time-stamp-pattern: "30/scriptversion=%:y-%02m-%02d.%02H; # UTC"
 # time-stamp-time-zone: "UTC"
 # End:

--- a/build-aux/funclib.sh
+++ b/build-aux/funclib.sh
@@ -1,5 +1,5 @@
 # Set a version string for this script.
-scriptversion=2016-02-28.16; # UTC
+scriptversion=2016-08-15.14; # UTC
 
 # General shell script boiler plate, and helper functions.
 # Written by Gary V. Vaughan, 2004
@@ -145,7 +145,7 @@ func_path_progs ()
           func_executable_p "$_G_path_prog" || continue
           case `"$_G_path_prog" --version 2>&1` in
             *GNU*) func_path_progs_result=$_G_path_prog _G_path_prog_found=: ;;
-            *)     $_G_check_func $_G_path_prog
+            *)     $_G_check_func "$_G_path_prog"
 		   func_path_progs_result=$func_check_prog_result
 		   ;;
           esac

--- a/build-aux/inline-source
+++ b/build-aux/inline-source
@@ -19,11 +19,11 @@
 # <https://github.com/gnulib-modules/bootstrap/issues>
 
 # Source required external libraries:
-. `echo "$0" |${SED-sed} 's|[^/]*$||'`"funclib.sh"
-. `echo "$0" |${SED-sed} 's|[^/]*$||'`"options-parser"
+. "`echo "$0" |${SED-sed} 's|[^/]*$||'`funclib.sh"
+. "`echo "$0" |${SED-sed} 's|[^/]*$||'`options-parser"
 
 # Set a version string for *this* script.
-scriptversion=2016-02-21.11; # UTC
+scriptversion=2016-08-16.15; # UTC
 
 
 ## ------ ##
@@ -34,9 +34,10 @@ scriptversion=2016-02-21.11; # UTC
 # from the command line.
 
 # Recursively scan through a FILE passed on the command line, replacing
-# either of the following:
+# any of the following:
 #   . "relative/file"
 #   . `echo "$0" |edit`"relative/file"
+#   . "`echo "$0" |edit`relative/file"
 # with the contents of the referenced files.
 
 
@@ -118,27 +119,38 @@ func_include ()
     _G_scriptdir=`echo "$1" |$SED 's|[^/]*$||'`
     test -n "$_G_scriptdir" || _G_scriptdir="./"
 
+    # quote progpath for use in AWK script
+    func_quote_arg unquoted "$progpath"
+    _G_qprogpath=$func_quote_arg_unquoted_result
+
     $AWK '
-        BEGIN { magic = '${_RECURSE_MAGIC-0}'; }
+        BEGIN { magic = '"${_RECURSE_MAGIC-0}"'; }
 
         /^#!/ && magic == 0 {
             print $0;
-            print "## DO NOT EDIT - This file generated from '$1'";
-            print "##               by '$progname' v'$scriptversion'";
+            print "## DO NOT EDIT - This file generated from '"$1"'";
+            print "##               by '"$progname"' v'"$scriptversion"'";
             magic++;
+            next;
+        }
+
+        /^\. "`echo [^`]*`[^"]*"$/ {
+            tail = substr ($0, match ($0, /[^"]`/) +2);
+	    file = substr (tail, 1, length (tail) -1);
+	    system (sprintf ("env _RECURSE_MAGIC=%d '\'"$_G_qprogpath"\'' '\'"$_G_scriptdir"'%s'\''", magic, file));
             next;
         }
 
         /^\. ['\''"].*['\''"]$/ {
             file = substr ($2, 2, length ($2) -2);
-	    system (sprintf ("env _RECURSE_MAGIC=%d '$progpath' %s", magic, file));
+	    system (sprintf ("env _RECURSE_MAGIC=%d '\'"$_G_qprogpath"\'' %s", magic, file));
             next;
         }
 
         /^\. `echo [^`]*`['\''"][^'\''"]*['\''"]$/ {
             tail = substr ($0, match ($0, /`['\''"]/));
 	    file = substr (tail, 3, length (tail) -3);
-	    system (sprintf ("env _RECURSE_MAGIC=%d '$progpath' '"$_G_scriptdir"'%s", magic, file));
+	    system (sprintf ("env _RECURSE_MAGIC=%d '\'"$_G_qprogpath"\'' '\'"$_G_scriptdir"'%s'\''", magic, file));
             next;
         }
 
@@ -154,6 +166,6 @@ exit 0
 # mode: shell-script
 # sh-indentation: 2
 # eval: (add-hook 'before-save-hook 'time-stamp)
-# time-stamp-pattern: "20/scriptversion=%:y-%02m-%02d.%02H; # UTC"
+# time-stamp-pattern: "30/scriptversion=%:y-%02m-%02d.%02H; # UTC"
 # time-stamp-time-zone: "UTC"
 # End:

--- a/tests/test-option-parser.sh
+++ b/tests/test-option-parser.sh
@@ -22,7 +22,7 @@ all_shells_script=$0
 
 . "$abs_aux_dir"/options-parser || exit 1
 
-helper="$__GL_ALL_SHELLS_SHELL $abs_srcdir/test-option-parser-helper"
+helper="$abs_srcdir/test-option-parser-helper"
 
 check_output_inner ()
 {
@@ -32,7 +32,7 @@ check_output_inner ()
     func_quote pretty ${1+"$@"}
     $ECHO "[[ output check ]] args: $func_quote_result"
 
-    output=`$helper ${1+"$@"} 2>/dev/null`
+    output=`$__GL_ALL_SHELLS_SHELL "$helper" ${1+"$@"} 2>/dev/null`
     rc=$?
     test "$rc" -eq "$exp_retval" \
         || all_shells_error "unexpected exit status $rc $exp_retval"
@@ -64,7 +64,7 @@ check_retval ()
     exp_retval=$1 ; shift
     func_quote pretty ${1+"$@"}
     $ECHO "[[ retval check ]] args: $func_quote_result"
-    $helper ${1+"$@"} >/dev/null 2>/dev/null
+    $__GL_ALL_SHELLS_SHELL "$helper" ${1+"$@"} >/dev/null 2>/dev/null
     rc=$?
     test "$rc" -eq "$exp_retval" \
         || all_shells_error "unexpected retval $rc (should be $exp_retval)"
@@ -79,7 +79,7 @@ grep_output ()
     func_quote pretty ${1+"$@"}
     $ECHO "[[ grep for '$grep_for' ]] args: $func_quote_result"
 
-    output=`$helper ${1+"$@"} 2>/dev/null`
+    output=`$__GL_ALL_SHELLS_SHELL "$helper" ${1+"$@"} 2>/dev/null`
     rc=$?
     case $output in
       *$grep_for*) : ;;


### PR DESCRIPTION
- build-aux/bootstrap.in: Quote paths in source includes.
- build-aux/extract-trace: Quote paths in source includes, correct
  time-stamp-pattern.
- build-aux/extract-trace (func_find_tool): Quote paths.
- build-aux/funclib.sh (func_path_progs): Quote paths.
- build-aux/inline-source: Quote paths in source includes, correct
  time-stamp-pattern.
- build-aux/inline-source (func_include): quote paths used in awk
  script, and add support for "correctly-quoted" include paths
  (. "`echo ..`path") to awk script.
- tests/test-option-parser.sh: Update helper usage to support correct
  path quoting.
- bootstrap: Regenerate.

Signed-off-by: Scott Shambarger devel@shambarger.net
