### PR TITLE
Change license of the bootstrap modules to “GPLed build tool”

### DIFF
--- a/modules/bootstrap
+++ b/modules/bootstrap
@@ -17,7 +17,7 @@ Makefile.am:
 Include:
 
 License:
-Dual MIT/GPLv2+
+GPLed build tool
 
 Maintainer:
 Gary V. Vaughan <gary@gnu.org>

--- a/modules/extract-trace
+++ b/modules/extract-trace
@@ -15,7 +15,7 @@ Makefile.am:
 Include:
 
 License:
-Dual MIT/GPLv2+
+GPLed build tool
 
 Maintainer:
 Gary V. Vaughan <gary@gnu.org>

--- a/modules/funclib.sh
+++ b/modules/funclib.sh
@@ -13,7 +13,7 @@ Makefile.am:
 Include:
 
 License:
-Dual MIT/GPLv2+
+GPLed build tool
 
 Maintainer:
 Gary V. Vaughan <gary@gnu.org>

--- a/modules/inline-source
+++ b/modules/inline-source
@@ -15,7 +15,7 @@ Makefile.am:
 Include:
 
 License:
-Dual MIT/GPLv2+
+GPLed build tool
 
 Maintainer:
 Gary V. Vaughan <gary@gnu.org>

--- a/modules/options-parser
+++ b/modules/options-parser
@@ -14,7 +14,7 @@ Makefile.am:
 Include:
 
 License:
-Dual MIT/GPLv2+
+GPLed build tool
 
 Maintainer:
 Gary V. Vaughan <gary@gnu.org>


### PR DESCRIPTION
Fixes issue #11.

This makes it possible to use with gnulib-tool --lgpl, while not affecting
MIT-licensed projects, as a build tool does not become part of the built
project.