### PR TITLE
maint: bump copyright years to 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ or redistributing the files in this software project:
 ------------------------------------------------------------------------
 <https://opensource.org/licenses/MIT>
 
-Copyright (C) 2004-2018 Bootstrap Authors
+Copyright (C) 2004-2019 Bootstrap Authors
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,6 @@
 #! /bin/sh
 ## DO NOT EDIT - This file generated from build-aux/bootstrap.in
-##               by inline-source v2018-07-24.06
+##               by inline-source v2019-02-19.15
 
 # Bootstrap an Autotooled package from checked-out sources.
 # Written by Gary V. Vaughan, 2010
@@ -9,7 +9,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2018 Bootstrap Authors
+# Copyright (C) 2010-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -224,7 +224,7 @@ vc_ignore=
 
 # Source required external libraries:
 # Set a version string for this script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 # General shell script boiler plate, and helper functions.
 # Written by Gary V. Vaughan, 2004
@@ -232,7 +232,7 @@ scriptversion=2018-07-24.06; # UTC
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2004-2018 Bootstrap Authors
+# Copyright (C) 2004-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -1657,7 +1657,7 @@ func_lt_ver ()
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2018 Bootstrap Authors
+# Copyright (C) 2010-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -1670,7 +1670,7 @@ func_lt_ver ()
 # <https://github.com/gnulib-modules/bootstrap/issues>
 
 # Set a version string for this script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------ ##
@@ -2342,7 +2342,7 @@ func_version ()
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2018 Bootstrap Authors
+# Copyright (C) 2010-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -2359,7 +2359,7 @@ test -z "$progpath" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/funclib.sh
 test extract-trace = "$progname" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/options-parser
 
 # Set a version string.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------ ##
@@ -2822,7 +2822,7 @@ test extract-trace = "$progname" && func_main "$@"
 # End:
 
 # Set a version string for *this* script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------------------- ##

--- a/build-aux/bootstrap.in
+++ b/build-aux/bootstrap.in
@@ -7,7 +7,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2018 Bootstrap Authors
+# Copyright (C) 2010-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -226,7 +226,7 @@ vc_ignore=
 . `echo "$0" |${SED-sed} 's|[^/]*$||'`"extract-trace"
 
 # Set a version string for *this* script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------------------- ##

--- a/build-aux/extract-trace
+++ b/build-aux/extract-trace
@@ -6,7 +6,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2018 Bootstrap Authors
+# Copyright (C) 2010-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -23,7 +23,7 @@ test -z "$progpath" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/funclib.sh
 test extract-trace = "$progname" && . `echo "$0" |${SED-sed} 's|[^/]*$||'`/options-parser
 
 # Set a version string.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------ ##

--- a/build-aux/funclib.sh
+++ b/build-aux/funclib.sh
@@ -1,5 +1,5 @@
 # Set a version string for this script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 # General shell script boiler plate, and helper functions.
 # Written by Gary V. Vaughan, 2004
@@ -7,7 +7,7 @@ scriptversion=2018-07-24.06; # UTC
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2004-2018 Bootstrap Authors
+# Copyright (C) 2004-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later

--- a/build-aux/inline-source
+++ b/build-aux/inline-source
@@ -6,7 +6,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2012-2018 Bootstrap Authors
+# Copyright (C) 2012-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -23,7 +23,7 @@
 . `echo "$0" |${SED-sed} 's|[^/]*$||'`"options-parser"
 
 # Set a version string for *this* script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------ ##

--- a/build-aux/options-parser
+++ b/build-aux/options-parser
@@ -6,7 +6,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2018 Bootstrap Authors
+# Copyright (C) 2010-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later
@@ -19,7 +19,7 @@
 # <https://github.com/gnulib-modules/bootstrap/issues>
 
 # Set a version string for this script.
-scriptversion=2018-07-24.06; # UTC
+scriptversion=2019-02-19.15; # UTC
 
 
 ## ------ ##

--- a/tests/test-all-shells.sh
+++ b/tests/test-all-shells.sh
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2018 Bootstrap Authors
+# Copyright (C) 2015-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later

--- a/tests/test-funclib-quote.sh
+++ b/tests/test-funclib-quote.sh
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2018 Bootstrap Authors
+# Copyright (C) 2015-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later

--- a/tests/test-option-parser-helper
+++ b/tests/test-option-parser-helper
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2018 Bootstrap Authors
+# Copyright (C) 2015-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later

--- a/tests/test-option-parser.sh
+++ b/tests/test-option-parser.sh
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2018 Bootstrap Authors
+# Copyright (C) 2015-2019 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/license/MIT>, and GPL version 2 or later


### PR DESCRIPTION
* LICENSE, Makefile, build-aux/bootstrap.in,
build-aux/extract-trace, build-aux/funclib.sh,
build-aux/inline-source, build-aux/options-parser,
tests/test-all-shells.sh, tests/test-funclib-quote.sh,
tests/test-option-parser-helper, tests/test-option-parser.sh: Bump
copyright to include 2018.
* bootstrap: Regenerate.