### PR TITLE
funclib.sh: unconditionally normalize LC_ALL, LANGUAGE

### DIFF
--- a/build-aux/funclib.sh
+++ b/build-aux/funclib.sh
@@ -65,6 +65,12 @@ do
 	  _G_safe_locale=\"$_G_var=C; \$_G_safe_locale\"
 	fi"
 done
+# These NLS vars are set unconditionally (bootstrap issue #24).  Unset those
+# in case the environment reset is needed later and the $save_* variant is not
+# defined (see the code above).
+LC_ALL=C
+LANGUAGE=C
+export LANGUAGE LC_ALL
 
 # Make sure IFS has a sensible default
 sp=' '


### PR DESCRIPTION
Caveat: Restoring the environment (when required) needs to be
done more carefully now, and those variables need to be properly unset
if the saved variants (e.g. $save_LC_ALL) are not defined, as is e.g.
already done by GNU Libtool:

  https://git.savannah.gnu.org/cgit/libtool.git/tree/build-aux/ltmain.in?id=b9b44533fbf7#n2052

* build-aux/funclib.sh: Unconditionally set LC_ALL and LANGUAGE to 'C',
to avoid semantic differences on MinGW.

Reported-by: Fabio Alemagna.
Fixes: #24