### PR TITLE
funclib.sh: remove slur from inline comments.

### DIFF
--- a/build-aux/funclib.sh
+++ b/build-aux/funclib.sh
@@ -78,7 +78,7 @@ nl='
 '
 IFS="$sp	$nl"
 
-# There are apparently some retarded systems that use ';' as a PATH separator!
+# There are apparently some systems that use ';' as a PATH separator!
 if test "${PATH_SEPARATOR+set}" != set; then
   PATH_SEPARATOR=:
   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {


### PR DESCRIPTION
I know this wasn't meant in a bad way, but this comment didn't age well in my opinion.
I mostly care because this comment gets added to `libtool` and `libtoolize` scripts because they include `funclib.sh` to provide a number of helper functions.