### PR TITLE
maint: bump copyright dates to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ or redistributing the files in this software project:
 ------------------------------------------------------------------------
 <https://opensource.org/licenses/MIT>
 
-Copyright (C) 2004-2019, 2021 Bootstrap Authors
+Copyright (C) 2004-2019, 2021, 2023 Bootstrap Authors
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 ## This is free software.  There is NO warranty; not even for
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ##
-## Copyright (C) 2014-2019, 2021 Bootstrap Authors
+## Copyright (C) 2014-2019, 2021, 2023 Bootstrap Authors
 ##
 ## This file is dual licensed under the terms of the MIT license
 ## <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/bootstrap
+++ b/bootstrap
@@ -9,7 +9,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2019, 2021 Bootstrap Authors
+# Copyright (C) 2010-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later
@@ -235,7 +235,7 @@ scriptversion=2019-02-19.15; # UTC
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2004-2019, 2021 Bootstrap Authors
+# Copyright (C) 2004-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later
@@ -306,7 +306,7 @@ nl='
 '
 IFS="$sp	$nl"
 
-# There are apparently some retarded systems that use ';' as a PATH separator!
+# There are apparently some systems that use ';' as a PATH separator!
 if test "${PATH_SEPARATOR+set}" != set; then
   PATH_SEPARATOR=:
   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
@@ -1699,7 +1699,7 @@ func_lt_ver ()
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2019, 2021 Bootstrap Authors
+# Copyright (C) 2010-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later
@@ -2384,7 +2384,7 @@ func_version ()
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2019, 2021 Bootstrap Authors
+# Copyright (C) 2010-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/build-aux/bootstrap.in
+++ b/build-aux/bootstrap.in
@@ -7,7 +7,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2019, 2021 Bootstrap Authors
+# Copyright (C) 2010-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/build-aux/extract-trace
+++ b/build-aux/extract-trace
@@ -6,7 +6,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2019, 2021 Bootstrap Authors
+# Copyright (C) 2010-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/build-aux/funclib.sh
+++ b/build-aux/funclib.sh
@@ -7,7 +7,7 @@ scriptversion=2019-02-19.15; # UTC
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2004-2019, 2021 Bootstrap Authors
+# Copyright (C) 2004-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/build-aux/inline-source
+++ b/build-aux/inline-source
@@ -6,7 +6,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2012-2019, 2021 Bootstrap Authors
+# Copyright (C) 2012-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/build-aux/options-parser
+++ b/build-aux/options-parser
@@ -6,7 +6,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2010-2019, 2021 Bootstrap Authors
+# Copyright (C) 2010-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/tests/test-all-shells.sh
+++ b/tests/test-all-shells.sh
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2019, 2021 Bootstrap Authors
+# Copyright (C) 2015-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/tests/test-funclib-quote.sh
+++ b/tests/test-funclib-quote.sh
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2019, 2021 Bootstrap Authors
+# Copyright (C) 2015-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/tests/test-option-parser-helper
+++ b/tests/test-option-parser-helper
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2019, 2021 Bootstrap Authors
+# Copyright (C) 2015-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later

--- a/tests/test-option-parser.sh
+++ b/tests/test-option-parser.sh
@@ -5,7 +5,7 @@
 # This is free software.  There is NO warranty; not even for
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
-# Copyright (C) 2015-2019, 2021 Bootstrap Authors
+# Copyright (C) 2015-2019, 2021, 2023 Bootstrap Authors
 #
 # This file is dual licensed under the terms of the MIT license
 # <https://opensource.org/licenses/MIT>, and GPL version 2 or later


### PR DESCRIPTION
Processed by command:
$ make UPDATE_COPYRIGHT_SCRIPT=/gnulib/build-aux/\ update-copyright update-copyright

* LICENSE, Makefile, build-aux/bootstrap.in, build-aux/extract-trace, build-aux/funclib.sh,
build-aux/inline-source, build-aux/options-parser, tests/test-all-shells.sh, tests/test-funclib-quote.sh, tests/test-option-parser-helper, tests/test-option-parser.sh: Bump copyright to include 2023.
* bootstrap: Regenerate.