### PR TITLE
When detecting `--shallow-since`, grep for just `shallow-since`

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -227,7 +227,7 @@ vc_ignore=
 
 # Source required external libraries:
 # Set a version string for this script.
-scriptversion=2019-02-19.15; # UTC
+scriptversion=2025-04-22.20; # UTC
 
 # General shell script boiler plate, and helper functions.
 # Written by Gary V. Vaughan, 2004
@@ -4260,7 +4260,7 @@ func_require_gnulib_submodule ()
 
         shallow=
         test -n "$gnulib_clone_since" && \
-            $GIT clone -h 2>&1 |func_grep_q -- --shallow-since \
+            $GIT clone -h 2>&1 |func_grep_q shallow-since \
             && shallow="--shallow-since=$gnulib_clone_since"
 
         func_show_eval "$GIT clone $shallow '$gnulib_url' '$gnulib_path'" \


### PR DESCRIPTION
Newer versions of git output `--[no-]shallow-since` in the help for `git
clone -h`, so the flag itself does not match.

Fixes #39.